### PR TITLE
feature/iqbal/server: Add WithCredentials from Client Side

### DIFF
--- a/client/src/modules/user/components/login.component.js
+++ b/client/src/modules/user/components/login.component.js
@@ -13,12 +13,18 @@ function Login() {
 
     async function loginHandler(values) {
         try {
-            const res = await axios.post("http://localhost:3000/users/login", {
-                email: values.email,
-                password: values.password,
-            });
+            const res = await axios.post(
+                "http://localhost:3002/users/login",
+                {
+                    email: values.email,
+                    password: values.password,
+                },
+                {
+                    withCredentials: true,
+                }
+            );
+
             if (res.status === 200) {
-                localStorage.setItem("access_token", res.data);
                 setLogin({
                     ...login,
                     loggedInn: true,
@@ -27,7 +33,7 @@ function Login() {
         } catch (err) {
             setLogin({
                 ...login,
-                error: "Invalid credintials",
+                error: "Invalid credentials",
             });
         }
     }


### PR DESCRIPTION
In your server-side login controller code, you are setting the access_token cookie with the value of token using the res.cookie method. The cookie is set to be httpOnly and signed.

This means that the cookie cannot be accessed or modified by client-side JavaScript code, and can only be sent back to the server with subsequent requests. Also, since the cookie is signed, it can be verified by the server to ensure that it has not been tampered with.

To access this cookie on the client-side, you can use the withCredentials option when making the Axios request. This will send the cookie along with the request, allowing the server to identify the user and authorize the request.